### PR TITLE
feat: persist task timer

### DIFF
--- a/frontend/taskery/src/App.jsx
+++ b/frontend/taskery/src/App.jsx
@@ -12,6 +12,7 @@ import { getToken, pickTokenFromURL, clearToken } from "./lib/auth";
 // ✅ Importa el board con dnd-kit
 import KanbanBoardDnd from "./components/KanbanBoardDnd";
 import { actualizarEstadoTarea, reordenarTareas } from "./services/tareas";
+import { getTimersByTask } from "./services/timers";
 
 // ✅ NUEVO: Contexto del timer + barra
 import { ActiveTimerProvider } from "./context/ActiveTimerContext";
@@ -101,7 +102,21 @@ export default function App() {
     setError("");
     try {
       const res = await api.get(`/tareas/${selectedProyecto.id}`);
-      setTareas(res.data || []);
+      const list = res.data || [];
+      const withTime = await Promise.all(
+        list.map(async (t) => {
+          try {
+            const timers = await getTimersByTask(t.id);
+            const totalMs = timers
+              .filter((tm) => tm.fin)
+              .reduce((acc, tm) => acc + (Date.parse(tm.fin) - Date.parse(tm.inicio)), 0);
+            return { ...t, totalMs };
+          } catch {
+            return { ...t, totalMs: 0 };
+          }
+        })
+      );
+      setTareas(withTime);
     } catch (err) {
       console.error("Error al cargar tareas:", err);
       setError("No se pudieron cargar las tareas.");
@@ -215,6 +230,7 @@ export default function App() {
                 tareas={tareas}
                 loading={loading || loadingTareas}
                 onAfterSave={loadTareas}
+                onTimerStopped={loadTareas}
                 onReorderSameColumn={async (col, idsOrdenados) => {
                   // Normaliza estado igual que el board
                   const norm = (e) => {
@@ -251,16 +267,6 @@ export default function App() {
                   // Optimista en UI: cambia estado y aplica orden en ambas columnas
                   setTareas((prev) => {
                     const byId = Object.fromEntries(prev.map((t) => [t.id, t]));
-                    const moved = byId[tareaId];
-
-                    // columna origen según estado previo
-                    const fromCol = (() => {
-                      const s = String(moved?.estado || "").toLowerCase();
-                      if (s.startsWith("en")) return "en_progreso";
-                      if (s.startsWith("comp")) return "completada";
-                      return "pendiente";
-                    })();
-
                     const targetTasks = targetIds.map((id) => ({ ...byId[id], estado: to }));
                     const sourceTasks = sourceIds.map((id) => byId[id]); // mantiene estado de origen
                     const keep = prev.filter(
@@ -329,13 +335,13 @@ export default function App() {
           onClose={() => setShowCreateTarea(false)}
           proyecto={selectedProyecto}
           onCreated={(nueva) => {
-            setTareas((prev) => [nueva, ...prev]);
+            setTareas((prev) => [{ ...nueva, totalMs: 0 }, ...prev]);
           }}
         />
       </div>
 
       {/* Barra global del temporizador */}
-      <TimeBar />
+      <TimeBar onStopped={loadTareas} />
     </ActiveTimerProvider>
   );
 }

--- a/frontend/taskery/src/components/BaseModal.jsx
+++ b/frontend/taskery/src/components/BaseModal.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from 'react'
-import { AnimatePresence, motion } from 'framer-motion'
+import { AnimatePresence, motion } from 'framer-motion' // eslint-disable-line no-unused-vars
 import FocusLock from 'react-focus-lock'
 
 /**

--- a/frontend/taskery/src/components/KanbanBoardDnd.jsx
+++ b/frontend/taskery/src/components/KanbanBoardDnd.jsx
@@ -50,7 +50,15 @@ function badgeColor(p) {
   }
 }
 
-function TareaCardSortable({ tarea, onEdit, activeTareaId, startTimer, stopTimer }) {
+function msToHMS(ms) {
+  const s = Math.floor(ms / 1000);
+  const h = String(Math.floor(s / 3600)).padStart(2, "0");
+  const m = String(Math.floor((s % 3600) / 60)).padStart(2, "0");
+  const ss = String(s % 60).padStart(2, "0");
+  return `${h}:${m}:${ss}`;
+}
+
+function TareaCardSortable({ tarea, onEdit, activeTareaId, startTimer, stopTimer, runningForMs, onTimerStopped }) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
     useSortable({ id: String(tarea.id) });
 
@@ -72,6 +80,8 @@ function TareaCardSortable({ tarea, onEdit, activeTareaId, startTimer, stopTimer
     e.stopPropagation();
   };
 
+  const displayMs = esActiva ? runningForMs : tarea.totalMs || 0;
+
   return (
     <li
       ref={setNodeRef}
@@ -91,6 +101,7 @@ function TareaCardSortable({ tarea, onEdit, activeTareaId, startTimer, stopTimer
                 {tarea.descripcion}
               </span>
             )}
+            <span className="text-xs font-mono text-slate-300/70 mt-1">{msToHMS(displayMs)}</span>
           </div>
 
           <div className="flex items-center gap-2 shrink-0">
@@ -142,9 +153,10 @@ function TareaCardSortable({ tarea, onEdit, activeTareaId, startTimer, stopTimer
             {esActiva && (
               <button
                 onMouseDown={stopDnd}
-                onClick={(e) => {
+                onClick={async (e) => {
                   stopDnd(e);
-                  stopTimer();
+                  await stopTimer();
+                  onTimerStopped?.();
                 }}
                 className="p-1.5 rounded bg-red-600/20 hover:bg-red-600/30"
                 title="Parar temporizador"
@@ -224,6 +236,7 @@ export default function KanbanBoardDnd({
   onReorderSameColumn, // (col, idsOrdenados)
   onMoveToColumn, // (tareaId, toCol, idsTarget, idsSource)
   onAfterSave, // opcional: refrescar tras guardar en el modal
+  onTimerStopped,
 }) {
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
@@ -231,7 +244,7 @@ export default function KanbanBoardDnd({
   );
 
   // 👇 CONSUME EL CONTEXTO DEL TIMER
-  const { active, start, stop } = useActiveTimer();
+  const { active, runningForMs, start, stop } = useActiveTimer();
   const activeTareaId = active?.tareaId ?? null;
 
   const grouped = useMemo(() => {
@@ -401,6 +414,8 @@ export default function KanbanBoardDnd({
                             activeTareaId={activeTareaId}
                             startTimer={start}
                             stopTimer={stop}
+                            runningForMs={runningForMs}
+                            onTimerStopped={onTimerStopped}
                             onEdit={(task) => {
                               setEditing(task);
                               setEditOpen(true);

--- a/frontend/taskery/src/components/TimeBar.jsx
+++ b/frontend/taskery/src/components/TimeBar.jsx
@@ -9,7 +9,7 @@ function msToHMS(ms) {
   return `${h}:${m}:${ss}`;
 }
 
-export default function TimerBar() {
+export default function TimerBar({ onStopped }) {
   const { active, runningForMs, stop } = useActiveTimer();
   if (!active) return null;
 
@@ -24,7 +24,10 @@ export default function TimerBar() {
       </strong>
       <span className="font-mono tabular-nums">{msToHMS(runningForMs)}</span>
       <button
-        onClick={stop}
+        onClick={async () => {
+          await stop();
+          onStopped?.();
+        }}
         className="ml-2 px-3 py-1 rounded-md bg-red-600 hover:bg-red-700 text-sm"
         title="Parar temporizador"
       >

--- a/frontend/taskery/src/context/ActiveTimerContext.jsx
+++ b/frontend/taskery/src/context/ActiveTimerContext.jsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext, useEffect, useMemo, useRef, useState } from 'react';
-import { getActiveTimer, startTimer, stopTimer } from '@/services/timers';
+import { getActiveTimer, getTimersByTask, startTimer, stopTimer } from '@/services/timers';
 
 const ActiveTimerContext = createContext(null);
 
@@ -7,6 +7,7 @@ export function ActiveTimerProvider({ children, refreshMs = 15000 }) {
   const [active, setActive] = useState(null);      // timer activo o null
   const [runningForMs, setRunningForMs] = useState(0);
   const [clockOffsetMs, setClockOffsetMs] = useState(0);
+  const [baseElapsedMs, setBaseElapsedMs] = useState(0);
   const tickRef = useRef(null);
 
   // Cargar el activo al montar
@@ -15,8 +16,14 @@ export function ActiveTimerProvider({ children, refreshMs = 15000 }) {
       try {
         const a = await getActiveTimer();
         if (a?.inicio) {
+          const timers = await getTimersByTask(a.tareaId);
+          const base = timers
+            .filter((t) => t.fin)
+            .reduce((acc, t) => acc + (Date.parse(t.fin) - Date.parse(t.inicio)), 0);
+          setBaseElapsedMs(base);
           setClockOffsetMs(Date.now() - Date.parse(a.inicio));
         } else {
+          setBaseElapsedMs(0);
           setClockOffsetMs(0);
         }
         setActive(a);
@@ -31,7 +38,7 @@ export function ActiveTimerProvider({ children, refreshMs = 15000 }) {
     if (active?.inicio) {
       const started = new Date(active.inicio).getTime();
       clearInterval(tickRef.current);
-      const compute = () => Date.now() - started - clockOffsetMs;
+      const compute = () => baseElapsedMs + Date.now() - started - clockOffsetMs;
       setRunningForMs(compute());
       tickRef.current = setInterval(() => {
         setRunningForMs(compute());
@@ -41,7 +48,7 @@ export function ActiveTimerProvider({ children, refreshMs = 15000 }) {
       clearInterval(tickRef.current);
       setRunningForMs(0);
     }
-  }, [active?.id, active?.inicio, clockOffsetMs]);
+  }, [active?.id, active?.inicio, clockOffsetMs, baseElapsedMs]);
 
   // Auto-refresh para sincronizar multi-pestaña
   useEffect(() => {
@@ -49,8 +56,14 @@ export function ActiveTimerProvider({ children, refreshMs = 15000 }) {
       try {
         const a = await getActiveTimer();
         if (a?.inicio) {
+          const timers = await getTimersByTask(a.tareaId);
+          const base = timers
+            .filter((t) => t.fin)
+            .reduce((acc, t) => acc + (Date.parse(t.fin) - Date.parse(t.inicio)), 0);
+          setBaseElapsedMs(base);
           setClockOffsetMs(Date.now() - Date.parse(a.inicio));
         } else {
+          setBaseElapsedMs(0);
           setClockOffsetMs(0);
         }
         setActive(a);
@@ -62,6 +75,11 @@ export function ActiveTimerProvider({ children, refreshMs = 15000 }) {
   async function start(tareaId, note) {
     try {
       const res = await startTimer(tareaId, note);
+      const timers = await getTimersByTask(tareaId);
+      const base = timers
+        .filter((t) => t.fin)
+        .reduce((acc, t) => acc + (Date.parse(t.fin) - Date.parse(t.inicio)), 0);
+      setBaseElapsedMs(base);
       setClockOffsetMs(Date.now() - Date.parse(res.newTimer.inicio));
       setActive(res.newTimer);
       return res;
@@ -70,8 +88,14 @@ export function ActiveTimerProvider({ children, refreshMs = 15000 }) {
       try {
         const a = await getActiveTimer();
         if (a?.inicio) {
+          const timers = await getTimersByTask(a.tareaId);
+          const base = timers
+            .filter((t) => t.fin)
+            .reduce((acc, t) => acc + (Date.parse(t.fin) - Date.parse(t.inicio)), 0);
+          setBaseElapsedMs(base);
           setClockOffsetMs(Date.now() - Date.parse(a.inicio));
         } else {
+          setBaseElapsedMs(0);
           setClockOffsetMs(0);
         }
         setActive(a);
@@ -82,12 +106,16 @@ export function ActiveTimerProvider({ children, refreshMs = 15000 }) {
   }
 
   async function stop() {
+    const final = runningForMs;
     await stopTimer();
     setActive(null);
     setClockOffsetMs(0);
+    setBaseElapsedMs(0);
+    setRunningForMs(0);
+    return final;
   }
 
-  const value = useMemo(() => ({ active, runningForMs, start, stop }), [active, runningForMs]);
+  const value = useMemo(() => ({ active, runningForMs, start, stop }), [active, runningForMs, start, stop]);
 
   return (
     <ActiveTimerContext.Provider value={value}>

--- a/frontend/taskery/src/services/tareas.js
+++ b/frontend/taskery/src/services/tareas.js
@@ -103,9 +103,11 @@ export async function moverTarea({ tareaId, proyectoId, to, targetIds, sourceIds
 }
 
 /** Heurística simple para deducir la columna origen (opcional) */
-function guessFromFromDiff(targetIds, sourceIds) {
+function guessFromFromDiff(targetIds = [], sourceIds = []) {
+  void targetIds;
+  void sourceIds;
   // Si quieres, puedes pasar el `from` explícito y no usar esto.
   // Lo dejo por si mueves esta lógica aquí y no quieres tocar más.
   // Devuelve 'pendiente' | 'en_progreso' | 'completada' | null
-  return null
+  return null;
 }

--- a/frontend/taskery/vite.config.js
+++ b/frontend/taskery/vite.config.js
@@ -2,6 +2,9 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import path from 'path' // ✅ Importamos 'path' para usar alias
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 // ⚠️ Estamos detrás de Apache en https://todo.bycram.dev
 //    - Vite escucha en 0.0.0.0:5173


### PR DESCRIPTION
## Summary
- track previous elapsed time when starting timers
- display accumulated time on task cards
- refresh tasks after stopping timers

## Testing
- `npm run lint`
- `npm test` (frontend) *(fails: Missing script: "test")*
- `npm test` (backend) *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b010b2e5a4832ab08d3466c6009678