### PR TITLE
feat: add company and project invitations

### DIFF
--- a/backend/controllers/empresa.controller.js
+++ b/backend/controllers/empresa.controller.js
@@ -141,8 +141,40 @@ async function listarEmpresasDelUsuario(req, res) {
   }
 }
 
+/**
+ * POST /empresas/:id/invitaciones
+ * Body: { email }
+ */
+async function invitarUsuarioAEmpresa(req, res) {
+  const { id } = req.params
+  const { email } = req.body
+  if (!email) return res.status(400).json({ error: 'email es requerido' })
+  try {
+    const empresaId = Number(id)
+    // verificar que solicitante pertenece a la empresa
+    const pertenece = await prisma.empresa.findFirst({
+      where: { id: empresaId, usuarios: { some: { id: req.usuario.id } } },
+      select: { id: true }
+    })
+    if (!pertenece) {
+      return res.status(403).json({ error: 'No tienes acceso a esta empresa' })
+    }
+    const usuario = await prisma.usuario.findUnique({ where: { email } })
+    if (!usuario) return res.status(404).json({ error: 'Usuario no encontrado' })
+    await prisma.empresa.update({
+      where: { id: empresaId },
+      data: { usuarios: { connect: { id: usuario.id } } }
+    })
+    return res.json({ ok: true })
+  } catch (error) {
+    console.error('[invitarUsuarioAEmpresa] Error:', error)
+    return res.status(500).json({ error: 'Error al invitar usuario' })
+  }
+}
+
 // Exporta cada función como propiedad del objeto exports
 exports.crearEmpresa = crearEmpresa
 exports.editarEmpresa = editarEmpresa
 exports.obtenerEmpresaPorId = obtenerEmpresaPorId
 exports.listarEmpresasDelUsuario = listarEmpresasDelUsuario
+exports.invitarUsuarioAEmpresa = invitarUsuarioAEmpresa

--- a/backend/controllers/proyecto.controller.js
+++ b/backend/controllers/proyecto.controller.js
@@ -44,7 +44,8 @@ async function crearProyecto(req, res) {
             : horasMensuales !== undefined
             ? Number(horasMensuales)
             : null,
-        empresa: { connect: { id: Number(empresaId) } }, // 👈 clave
+        empresa: { connect: { id: Number(empresaId) } },
+        usuarios: { connect: { id: Number(usuarioId) } },
       },
       select: {
         id: true,
@@ -106,6 +107,35 @@ async function listarProyectosPorEmpresa(req, res) {
     return res.json(proyectos)
   } catch (error) {
     console.error('[listarProyectosPorEmpresa] Error:', error)
+    return res.status(500).json({ error: 'Error al listar proyectos' })
+  }
+}
+
+/**
+ * GET /proyectos/mis-proyectos
+ * Lista todos los proyectos a los que pertenece el usuario
+ */
+async function listarMisProyectos(req, res) {
+  const usuarioId = req.usuario?.id
+  try {
+    const proyectos = await prisma.proyecto.findMany({
+      where: {
+        empresa: { usuarios: { some: { id: Number(usuarioId) } } },
+      },
+      select: {
+        id: true,
+        nombre: true,
+        descripcion: true,
+        horasMensuales: true,
+        empresa: { select: { id: true, nombre: true } },
+        createdAt: true,
+        updatedAt: true,
+      },
+      orderBy: { createdAt: 'desc' },
+    })
+    return res.json(proyectos)
+  } catch (error) {
+    console.error('[listarMisProyectos] Error:', error)
     return res.status(500).json({ error: 'Error al listar proyectos' })
   }
 }
@@ -174,5 +204,55 @@ async function editarProyecto(req, res) {
   }
 }
 
+/**
+ * POST /proyectos/:id/invitaciones
+ * Body: { email }
+ */
+async function invitarUsuarioAProyecto(req, res) {
+  const { id } = req.params
+  const { email } = req.body
+  if (!email) return res.status(400).json({ error: 'email es requerido' })
+  try {
+    const proyectoId = Number(id)
+    const proyecto = await prisma.proyecto.findUnique({
+      where: { id: proyectoId },
+      select: { id: true, empresaId: true },
+    })
+    if (!proyecto) return res.status(404).json({ error: 'Proyecto no encontrado' })
 
-module.exports = { crearProyecto, listarProyectosPorEmpresa, editarProyecto }
+    const pertenece = await prisma.empresa.findFirst({
+      where: { id: proyecto.empresaId, usuarios: { some: { id: req.usuario.id } } },
+      select: { id: true },
+    })
+    if (!pertenece) {
+      return res.status(403).json({ error: 'No tienes acceso a este proyecto' })
+    }
+
+    const usuario = await prisma.usuario.findUnique({ where: { email } })
+    if (!usuario) return res.status(404).json({ error: 'Usuario no encontrado' })
+
+    await prisma.proyecto.update({
+      where: { id: proyectoId },
+      data: { usuarios: { connect: { id: usuario.id } } },
+    })
+    // asegura que el usuario pertenezca a la empresa
+    await prisma.empresa.update({
+      where: { id: proyecto.empresaId },
+      data: { usuarios: { connect: { id: usuario.id } } },
+    }).catch(() => {})
+
+    return res.json({ ok: true })
+  } catch (error) {
+    console.error('[invitarUsuarioAProyecto] Error:', error)
+    return res.status(500).json({ error: 'Error al invitar usuario' })
+  }
+}
+
+
+module.exports = {
+  crearProyecto,
+  listarProyectosPorEmpresa,
+  listarMisProyectos,
+  editarProyecto,
+  invitarUsuarioAProyecto,
+}

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -50,6 +50,9 @@ model Usuario {
   // M:N con Empresa
   empresas Empresa[] @relation("EmpresasUsuarios")
 
+  // M:N con Proyecto
+  proyectos Proyecto[] @relation("ProyectosUsuarios")
+
   // M:N con Tarea (asignaciones)
   tareas Tarea[] @relation("UsuariosAsignados")
 
@@ -59,15 +62,16 @@ model Usuario {
 }
 
 model Proyecto {
-  id             Int      @id @default(autoincrement())
+  id             Int       @id @default(autoincrement())
   nombre         String
   descripcion    String?
   horasMensuales Int?
   empresaId      Int
-  empresa        Empresa  @relation(fields: [empresaId], references: [id])
+  empresa        Empresa   @relation(fields: [empresaId], references: [id])
   tareas         Tarea[]
-  createdAt      DateTime @default(now())
-  updatedAt      DateTime @updatedAt
+  usuarios       Usuario[] @relation("ProyectosUsuarios")
+  createdAt      DateTime  @default(now())
+  updatedAt      DateTime  @updatedAt
 
   @@index([empresaId])
 }

--- a/backend/routes/empresa.routes.js
+++ b/backend/routes/empresa.routes.js
@@ -14,6 +14,9 @@ router.get('/mis-empresas', verificarToken, empresaController.listarEmpresasDelU
 // Debe ser una función, por ejemplo:
 router.put('/:id', verificarToken, empresaController.editarEmpresa);
 
+// Invitar usuario a empresa
+router.post('/:id/invitaciones', verificarToken, empresaController.invitarUsuarioAEmpresa);
+
 // GET /empresas/:id  -> Devuelve la empresa, sus proyectos y usuarios
 router.get('/:id', verificarToken, empresaController.obtenerEmpresaPorId);
 

--- a/backend/routes/proyecto.routes.js
+++ b/backend/routes/proyecto.routes.js
@@ -1,7 +1,13 @@
 const express = require('express')
 const router = express.Router()
 
-const { crearProyecto, listarProyectosPorEmpresa, editarProyecto } = require('../controllers/proyecto.controller')
+const {
+  crearProyecto,
+  listarProyectosPorEmpresa,
+  listarMisProyectos,
+  editarProyecto,
+  invitarUsuarioAProyecto,
+} = require('../controllers/proyecto.controller')
 const { verificarToken } = require('../auth/jwt')
 
 // Crear nuevo proyecto (requiere token)
@@ -10,7 +16,13 @@ router.post('/', verificarToken, crearProyecto)
 // Obtener proyectos de la empresa del usuario autenticado
 router.get('/', verificarToken, listarProyectosPorEmpresa)
 
+// Obtener todos los proyectos del usuario
+router.get('/mis-proyectos', verificarToken, listarMisProyectos)
+
 // Editar proyecto
 router.put('/:id', verificarToken, editarProyecto)
+
+// Invitar usuario a proyecto
+router.post('/:id/invitaciones', verificarToken, invitarUsuarioAProyecto)
 
 module.exports = router

--- a/frontend/taskery/src/components/EmpresaModal.jsx
+++ b/frontend/taskery/src/components/EmpresaModal.jsx
@@ -1,0 +1,106 @@
+// src/components/EmpresaModal.jsx
+import React, { useEffect, useRef, useState } from 'react'
+import BaseModal from './BaseModal'
+import { crearEmpresa, editarEmpresa } from '@/services/empresas'
+
+export default function EmpresaModal({ open, onClose, initialData = null, onSaved }) {
+  const [nombre, setNombre] = useState('')
+  const [descripcion, setDescripcion] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+  const inputRef = useRef(null)
+
+  useEffect(() => {
+    if (open) {
+      setNombre(initialData?.nombre || '')
+      setDescripcion(initialData?.descripcion || '')
+      setError('')
+      setLoading(false)
+    }
+  }, [open, initialData])
+
+  async function handleSubmit(e) {
+    e.preventDefault()
+    setError('')
+    if (!nombre.trim()) {
+      setError('El nombre es obligatorio')
+      return
+    }
+    try {
+      setLoading(true)
+      if (initialData) {
+        await editarEmpresa(initialData.id, { nombre: nombre.trim(), descripcion: descripcion.trim() })
+      } else {
+        await crearEmpresa({ nombre: nombre.trim(), descripcion: descripcion.trim() || undefined })
+      }
+      onSaved?.()
+      onClose?.()
+    } catch (err) {
+      console.error('Error guardando empresa', err)
+      const msg = err?.response?.data?.error || err?.message || 'No se pudo guardar'
+      setError(msg)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  function handleClose() {
+    onClose?.()
+  }
+
+  return (
+    <BaseModal
+      open={open}
+      onClose={handleClose}
+      title={initialData ? 'Editar empresa' : 'Nueva empresa'}
+      initialFocusRef={inputRef}
+    >
+      {error && (
+        <div className="mt-4 rounded-xl border border-red-400/30 bg-red-500/10 px-3 py-2 text-sm text-red-200">
+          {error}
+        </div>
+      )}
+      <form onSubmit={handleSubmit} className="mt-4">
+        <label className="block text-sm text-white/80" htmlFor="empresa-nombre">
+          Nombre
+        </label>
+        <input
+          id="empresa-nombre"
+          ref={inputRef}
+          value={nombre}
+          onChange={e => setNombre(e.target.value)}
+          className="mt-1 w-full rounded-xl border border-white/10 bg-white/10 px-3 py-2 text-white outline-none focus:border-sky-400/40"
+          disabled={loading}
+        />
+        <label className="mt-4 block text-sm text-white/80" htmlFor="empresa-descripcion">
+          Descripción (opcional)
+        </label>
+        <textarea
+          id="empresa-descripcion"
+          value={descripcion}
+          onChange={e => setDescripcion(e.target.value)}
+          rows={3}
+          className="mt-1 w-full rounded-xl border border-white/10 bg-white/10 px-3 py-2 text-white outline-none focus:border-sky-400/40"
+          disabled={loading}
+        />
+        <div className="mt-6 flex justify-end gap-3">
+          <button
+            type="button"
+            onClick={handleClose}
+            className="rounded-xl border border-white/10 bg-white/5 px-4 py-2 text-white/80 hover:bg-white/10"
+            disabled={loading}
+          >
+            Cancelar
+          </button>
+          <button
+            type="submit"
+            disabled={loading}
+            className="rounded-xl bg-sky-500 px-4 py-2 font-semibold text-white hover:bg-sky-600 disabled:opacity-50"
+          >
+            {loading ? 'Guardando…' : 'Guardar'}
+          </button>
+        </div>
+      </form>
+    </BaseModal>
+  )
+}

--- a/frontend/taskery/src/components/InviteModal.jsx
+++ b/frontend/taskery/src/components/InviteModal.jsx
@@ -1,0 +1,87 @@
+import React, { useRef, useState } from 'react'
+import BaseModal from './BaseModal'
+
+export default function InviteModal({ open, onClose, title = 'Invitar', onInvite }) {
+  const [email, setEmail] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+  const inputRef = useRef(null)
+
+  function reset() {
+    setEmail('')
+    setError('')
+    setLoading(false)
+  }
+
+  function handleClose() {
+    reset()
+    onClose?.()
+  }
+
+  async function handleSubmit(e) {
+    e.preventDefault()
+    setError('')
+    if (!email.trim()) {
+      setError('El correo es obligatorio')
+      return
+    }
+    try {
+      setLoading(true)
+      await onInvite?.(email.trim())
+      handleClose()
+    } catch (err) {
+      console.error('Error invitando', err)
+      const msg = err?.response?.data?.error || err?.message || 'No se pudo invitar'
+      setError(msg)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <BaseModal
+      open={open}
+      onClose={handleClose}
+      title={title}
+      initialFocusRef={inputRef}
+    >
+      {error && (
+        <div className="mt-4 rounded-xl border border-red-400/30 bg-red-500/10 px-3 py-2 text-sm text-red-200">
+          {error}
+        </div>
+      )}
+      <form onSubmit={handleSubmit} className="mt-4">
+        <label className="block text-sm text-white/80" htmlFor="invite-email">
+          Correo electrónico
+        </label>
+        <input
+          id="invite-email"
+          ref={inputRef}
+          type="email"
+          value={email}
+          onChange={e => setEmail(e.target.value)}
+          className="mt-1 w-full rounded-xl border border-white/10 bg-white/10 px-3 py-2 text-white outline-none focus:border-sky-400/40"
+          placeholder="ejemplo@correo.com"
+          disabled={loading}
+        />
+        <div className="mt-6 flex justify-end gap-3">
+          <button
+            type="button"
+            onClick={handleClose}
+            className="rounded-xl border border-white/10 bg-white/5 px-4 py-2 text-white/80 hover:bg-white/10"
+            disabled={loading}
+          >
+            Cancelar
+          </button>
+          <button
+            type="submit"
+            disabled={loading}
+            className="rounded-xl bg-sky-500 px-4 py-2 font-semibold text-white hover:bg-sky-600 disabled:opacity-50"
+          >
+            {loading ? 'Invitando…' : 'Invitar'}
+          </button>
+        </div>
+      </form>
+    </BaseModal>
+  )
+}

--- a/frontend/taskery/src/components/ProyectoModal.jsx
+++ b/frontend/taskery/src/components/ProyectoModal.jsx
@@ -1,0 +1,128 @@
+// src/components/ProyectoModal.jsx
+import React, { useEffect, useRef, useState } from 'react'
+import BaseModal from './BaseModal'
+import { crearProyecto, editarProyecto } from '@/services/proyectos'
+
+export default function ProyectoModal({ open, onClose, initialData = null, onSaved, empresaId }) {
+  const [nombre, setNombre] = useState('')
+  const [descripcion, setDescripcion] = useState('')
+  const [horasMensuales, setHorasMensuales] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+  const inputRef = useRef(null)
+
+  useEffect(() => {
+    if (open) {
+      setNombre(initialData?.nombre || '')
+      setDescripcion(initialData?.descripcion || '')
+      setHorasMensuales(initialData?.horasMensuales || '')
+      setError('')
+      setLoading(false)
+    }
+  }, [open, initialData])
+
+  async function handleSubmit(e) {
+    e.preventDefault()
+    setError('')
+    if (!nombre.trim()) {
+      setError('El nombre es obligatorio')
+      return
+    }
+    try {
+      setLoading(true)
+      if (initialData) {
+        await editarProyecto(initialData.id, {
+          nombre: nombre.trim(),
+          descripcion: descripcion.trim() || null,
+          horasMensuales: horasMensuales ? Number(horasMensuales) : undefined
+        })
+      } else {
+        await crearProyecto({
+          nombre: nombre.trim(),
+          descripcion: descripcion.trim() || undefined,
+          horasMensuales: horasMensuales ? Number(horasMensuales) : undefined,
+          empresaId
+        })
+      }
+      onSaved?.()
+      onClose?.()
+    } catch (err) {
+      console.error('Error guardando proyecto', err)
+      const msg = err?.response?.data?.error || err?.message || 'No se pudo guardar'
+      setError(msg)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  function handleClose() {
+    onClose?.()
+  }
+
+  return (
+    <BaseModal
+      open={open}
+      onClose={handleClose}
+      title={initialData ? 'Editar proyecto' : 'Nuevo proyecto'}
+      initialFocusRef={inputRef}
+    >
+      {error && (
+        <div className="mt-4 rounded-xl border border-red-400/30 bg-red-500/10 px-3 py-2 text-sm text-red-200">
+          {error}
+        </div>
+      )}
+      <form onSubmit={handleSubmit} className="mt-4">
+        <label className="block text-sm text-white/80" htmlFor="proyecto-nombre">
+          Nombre
+        </label>
+        <input
+          id="proyecto-nombre"
+          ref={inputRef}
+          value={nombre}
+          onChange={e => setNombre(e.target.value)}
+          className="mt-1 w-full rounded-xl border border-white/10 bg-white/10 px-3 py-2 text-white outline-none focus:border-sky-400/40"
+          disabled={loading}
+        />
+        <label className="mt-4 block text-sm text-white/80" htmlFor="proyecto-descripcion">
+          Descripción (opcional)
+        </label>
+        <textarea
+          id="proyecto-descripcion"
+          value={descripcion}
+          onChange={e => setDescripcion(e.target.value)}
+          rows={3}
+          className="mt-1 w-full rounded-xl border border-white/10 bg-white/10 px-3 py-2 text-white outline-none focus:border-sky-400/40"
+          disabled={loading}
+        />
+        <label className="mt-4 block text-sm text-white/80" htmlFor="proyecto-horas">
+          Horas mensuales (opcional)
+        </label>
+        <input
+          id="proyecto-horas"
+          type="number"
+          value={horasMensuales}
+          onChange={e => setHorasMensuales(e.target.value)}
+          className="mt-1 w-full rounded-xl border border-white/10 bg-white/10 px-3 py-2 text-white outline-none focus:border-sky-400/40"
+          disabled={loading}
+        />
+        <div className="mt-6 flex justify-end gap-3">
+          <button
+            type="button"
+            onClick={handleClose}
+            className="rounded-xl border border-white/10 bg-white/5 px-4 py-2 text-white/80 hover:bg-white/10"
+            disabled={loading}
+          >
+            Cancelar
+          </button>
+          <button
+            type="submit"
+            disabled={loading}
+            className="rounded-xl bg-sky-500 px-4 py-2 font-semibold text-white hover:bg-sky-600 disabled:opacity-50"
+          >
+            {loading ? 'Guardando…' : 'Guardar'}
+          </button>
+        </div>
+      </form>
+    </BaseModal>
+  )
+}

--- a/frontend/taskery/src/pages/EmpresasPage.jsx
+++ b/frontend/taskery/src/pages/EmpresasPage.jsx
@@ -1,12 +1,15 @@
 // src/pages/EmpresasPage.jsx
 import React, { useEffect, useState } from 'react'
-import { listarMisEmpresas } from '@/services/empresas'
+import { listarMisEmpresas, invitarUsuarioAEmpresa } from '@/services/empresas'
 import EmpresaModal from '@/components/EmpresaModal'
+import InviteModal from '@/components/InviteModal'
 
 export default function EmpresasPage() {
   const [empresas, setEmpresas] = useState([])
   const [open, setOpen] = useState(false)
   const [editing, setEditing] = useState(null)
+  const [inviteOpen, setInviteOpen] = useState(false)
+  const [empresaInvitando, setEmpresaInvitando] = useState(null)
 
   async function load() {
     const data = await listarMisEmpresas()
@@ -27,21 +30,39 @@ export default function EmpresasPage() {
       </div>
 
       <ul className="space-y-2">
-        {empresas.map(e => (
-          <li key={e.id}
-              className="p-3 rounded-xl bg-slate-800 border border-white/10 flex justify-between items-center">
-            <div>
-              <div className="text-slate-100 font-medium">{e.nombre}</div>
-              {e.descripcion && <div className="text-slate-300/80 text-sm">{e.descripcion}</div>}
-            </div>
-            <button
-              onClick={() => { setEditing(e); setOpen(true) }}
-              className="px-3 py-2 rounded-lg bg-slate-700 hover:bg-slate-600"
+          {empresas.map(e => (
+            <li
+              key={e.id}
+              className="p-3 rounded-xl bg-slate-800 border border-white/10 flex justify-between items-center"
             >
-              Editar
-            </button>
-          </li>
-        ))}
+              <div>
+                <div className="text-slate-100 font-medium">{e.nombre}</div>
+                {e.descripcion && (
+                  <div className="text-slate-300/80 text-sm">{e.descripcion}</div>
+                )}
+              </div>
+              <div className="flex gap-2">
+                <button
+                  onClick={() => {
+                    setEmpresaInvitando(e)
+                    setInviteOpen(true)
+                  }}
+                  className="px-3 py-2 rounded-lg bg-slate-700 hover:bg-slate-600"
+                >
+                  Invitar
+                </button>
+                <button
+                  onClick={() => {
+                    setEditing(e)
+                    setOpen(true)
+                  }}
+                  className="px-3 py-2 rounded-lg bg-slate-700 hover:bg-slate-600"
+                >
+                  Editar
+                </button>
+              </div>
+            </li>
+          ))}
       </ul>
 
       <EmpresaModal
@@ -49,6 +70,12 @@ export default function EmpresasPage() {
         onClose={() => setOpen(false)}
         initialData={editing}
         onSaved={load}
+      />
+      <InviteModal
+        open={inviteOpen}
+        onClose={() => setInviteOpen(false)}
+        title={empresaInvitando ? `Invitar a ${empresaInvitando.nombre}` : 'Invitar'}
+        onInvite={email => invitarUsuarioAEmpresa(empresaInvitando.id, email)}
       />
     </div>
   )

--- a/frontend/taskery/src/pages/ProyectosPage.jsx
+++ b/frontend/taskery/src/pages/ProyectosPage.jsx
@@ -1,57 +1,86 @@
 // src/pages/ProyectosPage.jsx
 import React, { useEffect, useState } from 'react'
-import { listarProyectosPorEmpresa } from '@/services/proyectos'
+import { listarProyectosPorEmpresa, listarProyectos, invitarUsuarioAProyecto } from '@/services/proyectos'
 import ProyectoModal from '@/components/ProyectoModal'
+import InviteModal from '@/components/InviteModal'
 import { Pencil } from 'lucide-react'
 
 export default function ProyectosPage({ empresaId }) {
   const [proyectos, setProyectos] = useState([])
   const [open, setOpen] = useState(false)
   const [editing, setEditing] = useState(null)
+  const [inviteOpen, setInviteOpen] = useState(false)
+  const [proyectoInvitando, setProyectoInvitando] = useState(null)
 
   async function load() {
-    const data = await listarProyectosPorEmpresa(empresaId)
+    const data = empresaId ? await listarProyectosPorEmpresa(empresaId) : await listarProyectos()
     setProyectos(data || [])
   }
-  useEffect(() => { if (empresaId) load() }, [empresaId])
+  useEffect(() => { load() }, [empresaId])
 
   return (
     <div className="p-4">
-      <div className="flex justify-between mb-3">
-        <h1 className="text-xl text-sky-200">Proyectos</h1>
-        <button
-          onClick={() => { setEditing(null); setOpen(true) }}
-          className="px-3 py-2 rounded-lg bg-sky-600 hover:bg-sky-500"
-        >
-          Nuevo
-        </button>
-      </div>
+        <div className="flex justify-between mb-3">
+          <h1 className="text-xl text-sky-200">Proyectos</h1>
+          {empresaId && (
+            <button
+              onClick={() => { setEditing(null); setOpen(true) }}
+              className="px-3 py-2 rounded-lg bg-sky-600 hover:bg-sky-500"
+            >
+              Nuevo
+            </button>
+          )}
+        </div>
 
       <ul className="space-y-2">
         {proyectos.map(p => (
-          <li key={p.id}
-              className="p-3 rounded-xl bg-slate-800 border border-white/10 flex justify-between items-center">
-            <div>
-              <div className="text-slate-100 font-medium">{p.nombre}</div>
-              {p.descripcion && <div className="text-slate-300/80 text-sm">{p.descripcion}</div>}
-            </div>
-            <button
-              onClick={() => { setEditing(p); setOpen(true) }}
-              className="p-2 rounded-lg hover:bg-slate-700"
+            <li
+              key={p.id}
+              className="p-3 rounded-xl bg-slate-800 border border-white/10 flex justify-between items-center"
             >
-              <Pencil className="w-4 h-4 text-slate-300" />
-            </button>
-          </li>
-        ))}
-      </ul>
+              <div>
+                <div className="text-slate-100 font-medium">{p.nombre}</div>
+                {p.descripcion && (
+                  <div className="text-slate-300/80 text-sm">{p.descripcion}</div>
+                )}
+              </div>
+              <div className="flex gap-2">
+                <button
+                  onClick={() => {
+                    setProyectoInvitando(p)
+                    setInviteOpen(true)
+                  }}
+                  className="p-2 rounded-lg hover:bg-slate-700"
+                >
+                  Invitar
+                </button>
+                <button
+                  onClick={() => {
+                    setEditing(p)
+                    setOpen(true)
+                  }}
+                  className="p-2 rounded-lg hover:bg-slate-700"
+                >
+                  <Pencil className="w-4 h-4 text-slate-300" />
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
 
-      <ProyectoModal
-        open={open}
-        onClose={() => setOpen(false)}
-        initialData={editing}
-        empresaId={empresaId}
-        onSaved={load}
-      />
-    </div>
-  )
-}
+        <ProyectoModal
+          open={open}
+          onClose={() => setOpen(false)}
+          initialData={editing}
+          empresaId={empresaId}
+          onSaved={load}
+        />
+        <InviteModal
+          open={inviteOpen}
+          onClose={() => setInviteOpen(false)}
+          title={proyectoInvitando ? `Invitar a ${proyectoInvitando.nombre}` : 'Invitar'}
+          onInvite={email => invitarUsuarioAProyecto(proyectoInvitando.id, email)}
+        />
+      </div>
+    )
+  }

--- a/frontend/taskery/src/services/empresas.js
+++ b/frontend/taskery/src/services/empresas.js
@@ -20,3 +20,8 @@ export async function editarEmpresa(id, payload) {
   const { data } = await api.put(`/empresas/${id}`, payload);
   return data;
 }
+
+export async function invitarUsuarioAEmpresa(id, email) {
+  const { data } = await api.post(`/empresas/${id}/invitaciones`, { email });
+  return data;
+}

--- a/frontend/taskery/src/services/proyectos.js
+++ b/frontend/taskery/src/services/proyectos.js
@@ -11,7 +11,17 @@ export async function listarProyectosPorEmpresa(empresaId) {
   return data;
 }
 
+export async function listarProyectos() {
+  const { data } = await api.get('/proyectos/mis-proyectos');
+  return data;
+}
+
 export async function editarProyecto(id, payload) {
   const { data } = await api.put(`/proyectos/${id}`, payload);
+  return data;
+}
+
+export async function invitarUsuarioAProyecto(id, email) {
+  const { data } = await api.post(`/proyectos/${id}/invitaciones`, { email });
   return data;
 }


### PR DESCRIPTION
## Summary
- allow inviting users to companies and projects with new APIs
- add reusable modal components for editing and inviting entities
- list all accessible projects for current user

## Testing
- `npm test` (backend) *(fails: Error: no test specified)*
- `npm test` (frontend/taskery) *(fails: Missing script: "test")*
- `npm run lint` (frontend/taskery)


------
https://chatgpt.com/codex/tasks/task_e_68b017e9f6a0832aa2f226030f1020c9