### PR TITLE
feat: enhance navbar design

### DIFF
--- a/frontend/taskery/src/App.jsx
+++ b/frontend/taskery/src/App.jsx
@@ -152,7 +152,7 @@ export default function App() {
 
   return (
     <ActiveTimerProvider>
-      <NavBar />
+      <NavBar onLogout={handleLogout} />
       <div className="min-h-screen flex bg-neutral-950 text-white">
         {/* Fondo */}
         <div
@@ -209,12 +209,6 @@ export default function App() {
                   {error}
                 </span>
               )}
-              <button
-                onClick={handleLogout}
-                className="text-xs px-3 py-1.5 rounded-xl bg:white/5 hover:bg-white/10 border border-white/10"
-              >
-                Cerrar sesión
-              </button>
             </div>
           </header>
 

--- a/frontend/taskery/src/components/NavBar.jsx
+++ b/frontend/taskery/src/components/NavBar.jsx
@@ -1,12 +1,28 @@
-import React from 'react'
-import { Link } from 'react-router-dom'
+import React from "react"
+import { Link } from "react-router-dom"
 
-export default function NavBar() {
+export default function NavBar({ onLogout }) {
   return (
-    <nav className="bg-slate-900 text-white p-4 flex gap-4">
-      <Link className="hover:text-sky-400" to="/">Tablero</Link>
-      <Link className="hover:text-sky-400" to="/empresas">Empresas</Link>
-      <Link className="hover:text-sky-400" to="/proyectos">Proyectos</Link>
+    <nav className="sticky top-0 z-10 bg-white/5 backdrop-blur border-b border-white/10 shadow-[0_10px_40px_-20px_rgba(59,162,237,0.25)] text-white px-6 py-3 flex items-center justify-between">
+      <div className="flex items-center gap-8">
+        <Link to="/" className="shrink-0">
+          <img src="/Taskery-logo.webp" alt="Taskery Logo" className="h-8" />
+        </Link>
+        <div className="flex gap-4 text-sm">
+          <Link className="hover:text-sky-400" to="/">Tablero</Link>
+          <Link className="hover:text-sky-400" to="/empresas">Empresas</Link>
+          <Link className="hover:text-sky-400" to="/proyectos">Proyectos</Link>
+        </div>
+      </div>
+
+      {onLogout && (
+        <button
+          onClick={onLogout}
+          className="text-xs px-3 py-1.5 rounded-xl bg-white/10 hover:bg-white/15 border border-white/10"
+        >
+          Cerrar sesión
+        </button>
+      )}
     </nav>
   )
 }

--- a/frontend/taskery/src/components/Sidebar/Sidebar.jsx
+++ b/frontend/taskery/src/components/Sidebar/Sidebar.jsx
@@ -11,10 +11,6 @@ export default function Sidebar({
 }) {
   return (
     <aside className="w-72 bg-white/5 backdrop-blur border border-white/10 shadow-[0_10px_40px_-20px_rgba(59,162,237,0.25)] flex flex-col p-6">
-      <div className="mb-6 flex items-center gap-2">
-        <img src="/Taskery-logo.webp" alt="Taskery Logo" />
-      </div>
-
       {/* Empresa selector */}
       <div className="mb-4">
         <label className="block text-xs text-slate-300/80 mb-1">Empresa</label>

--- a/frontend/taskery/src/pages/EmpresasPage.jsx
+++ b/frontend/taskery/src/pages/EmpresasPage.jsx
@@ -25,67 +25,79 @@ export default function EmpresasPage() {
 
   return (
     <>
-    <NavBar />
-    <div className="p-4">
-      <div className="flex justify-between mb-3">
-        <h1 className="text-xl text-sky-200">Empresas</h1>
-        <button
-          onClick={() => { setEditing(null); setOpen(true) }}
-          className="px-3 py-2 rounded-lg bg-sky-600 hover:bg-sky-500"
-        >
-          Nueva
-        </button>
-      </div>
-
-      <ul className="space-y-2">
-          {empresas.map(e => (
-            <li
-              key={e.id}
-              className="p-3 rounded-xl bg-slate-800 border border-white/10 flex justify-between items-center"
+      <NavBar />
+      <div className="min-h-screen bg-neutral-950 text-white relative">
+        <div
+          className="absolute inset-0 -z-10"
+          style={{
+            background:
+              'radial-gradient(60rem 40rem at -10% -20%, rgba(59,162,237,0.10), transparent 60%), radial-gradient(40rem 30rem at 110% -10%, rgba(59,162,237,0.08), transparent 55%)'
+          }}
+        />
+        <div className="max-w-3xl mx-auto p-6">
+          <header className="flex justify-between items-center mb-6">
+            <h1 className="text-2xl font-semibold text-sky-300">Empresas</h1>
+            <button
+              onClick={() => {
+                setEditing(null)
+                setOpen(true)
+              }}
+              className="text-xs px-3 py-1.5 rounded-xl bg-sky-500 hover:bg-sky-600 font-semibold"
             >
-              <div>
-                <div className="text-slate-100 font-medium">{e.nombre}</div>
-                {e.descripcion && (
-                  <div className="text-slate-300/80 text-sm">{e.descripcion}</div>
-                )}
-              </div>
-              <div className="flex gap-2">
-                <button
-                  onClick={() => {
-                    setEmpresaInvitando(e)
-                    setInviteOpen(true)
-                  }}
-                  className="px-3 py-2 rounded-lg bg-slate-700 hover:bg-slate-600"
-                >
-                  Invitar
-                </button>
-                <button
-                  onClick={() => {
-                    setEditing(e)
-                    setOpen(true)
-                  }}
-                  className="px-3 py-2 rounded-lg bg-slate-700 hover:bg-slate-600"
-                >
-                  Editar
-                </button>
-              </div>
-            </li>
-          ))}
-      </ul>
+              Nueva
+            </button>
+          </header>
 
-      <EmpresaModal
-        open={open}
-        onClose={() => setOpen(false)}
-        initialData={editing}
-        onSaved={load}
-      />
-      <InviteModal
-        open={inviteOpen}
-        onClose={() => setInviteOpen(false)}
-        title={empresaInvitando ? `Invitar a ${empresaInvitando.nombre}` : 'Invitar'}
-        onInvite={email => invitarUsuarioAEmpresa(empresaInvitando.id, email)}
-      />
-    </div>
+          <ul className="space-y-3">
+            {empresas.map(e => (
+              <li
+                key={e.id}
+                className="p-4 rounded-xl bg-white/5 backdrop-blur border border-white/10 flex justify-between items-center"
+              >
+                <div>
+                  <div className="text-slate-100 font-medium">{e.nombre}</div>
+                  {e.descripcion && (
+                    <div className="text-slate-300/80 text-sm">{e.descripcion}</div>
+                  )}
+                </div>
+                <div className="flex gap-2">
+                  <button
+                    onClick={() => {
+                      setEmpresaInvitando(e)
+                      setInviteOpen(true)
+                    }}
+                    className="text-xs px-3 py-1.5 rounded-xl bg-white/10 hover:bg-white/15 border border-white/10"
+                  >
+                    Invitar
+                  </button>
+                  <button
+                    onClick={() => {
+                      setEditing(e)
+                      setOpen(true)
+                    }}
+                    className="text-xs px-3 py-1.5 rounded-xl bg-white/10 hover:bg-white/15 border border-white/10"
+                  >
+                    Editar
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ul>
+
+          <EmpresaModal
+            open={open}
+            onClose={() => setOpen(false)}
+            initialData={editing}
+            onSaved={load}
+          />
+          <InviteModal
+            open={inviteOpen}
+            onClose={() => setInviteOpen(false)}
+            title={empresaInvitando ? `Invitar a ${empresaInvitando.nombre}` : 'Invitar'}
+            onInvite={email => invitarUsuarioAEmpresa(empresaInvitando.id, email)}
+          />
+        </div>
+      </div>
     </>
   )
 }

--- a/frontend/taskery/src/pages/ProyectosPage.jsx
+++ b/frontend/taskery/src/pages/ProyectosPage.jsx
@@ -27,72 +27,82 @@ export default function ProyectosPage({ empresaId }) {
 
   return (
     <>
-    <NavBar />
-    <div className="p-4">
-        <div className="flex justify-between mb-3">
-          <h1 className="text-xl text-sky-200">Proyectos</h1>
-          {empresaId && (
-            <button
-              onClick={() => { setEditing(null); setOpen(true) }}
-              className="px-3 py-2 rounded-lg bg-sky-600 hover:bg-sky-500"
-            >
-              Nuevo
-            </button>
-          )}
+      <NavBar />
+      <div className="min-h-screen bg-neutral-950 text-white relative">
+        <div
+          className="absolute inset-0 -z-10"
+          style={{
+            background:
+              'radial-gradient(60rem 40rem at -10% -20%, rgba(59,162,237,0.10), transparent 60%), radial-gradient(40rem 30rem at 110% -10%, rgba(59,162,237,0.08), transparent 55%)'
+          }}
+        />
+        <div className="max-w-3xl mx-auto p-6">
+          <header className="flex justify-between items-center mb-6">
+            <h1 className="text-2xl font-semibold text-sky-300">Proyectos</h1>
+            {empresaId && (
+              <button
+                onClick={() => {
+                  setEditing(null)
+                  setOpen(true)
+                }}
+                className="text-xs px-3 py-1.5 rounded-xl bg-sky-500 hover:bg-sky-600 font-semibold"
+              >
+                Nuevo
+              </button>
+            )}
+          </header>
+
+          <ul className="space-y-3">
+            {proyectos.map(p => (
+              <li
+                key={p.id}
+                className="p-4 rounded-xl bg-white/5 backdrop-blur border border-white/10 flex justify-between items-center"
+              >
+                <div>
+                  <div className="text-slate-100 font-medium">{p.nombre}</div>
+                  {p.descripcion && (
+                    <div className="text-slate-300/80 text-sm">{p.descripcion}</div>
+                  )}
+                </div>
+                <div className="flex gap-2">
+                  <button
+                    onClick={() => {
+                      setProyectoInvitando(p)
+                      setInviteOpen(true)
+                    }}
+                    className="text-xs px-3 py-1.5 rounded-xl bg-white/10 hover:bg-white/15 border border-white/10"
+                  >
+                    Invitar
+                  </button>
+                  <button
+                    onClick={() => {
+                      setEditing(p)
+                      setOpen(true)
+                    }}
+                    className="text-xs px-3 py-1.5 rounded-xl bg-white/10 hover:bg-white/15 border border-white/10"
+                  >
+                    <Pencil className="w-4 h-4 text-slate-300" />
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ul>
+
+          <ProyectoModal
+            open={open}
+            onClose={() => setOpen(false)}
+            initialData={editing}
+            empresaId={empresaId}
+            onSaved={load}
+          />
+          <InviteModal
+            open={inviteOpen}
+            onClose={() => setInviteOpen(false)}
+            title={proyectoInvitando ? `Invitar a ${proyectoInvitando.nombre}` : 'Invitar'}
+            onInvite={email => invitarUsuarioAProyecto(proyectoInvitando.id, email)}
+          />
         </div>
-
-      <ul className="space-y-2">
-        {proyectos.map(p => (
-            <li
-              key={p.id}
-              className="p-3 rounded-xl bg-slate-800 border border-white/10 flex justify-between items-center"
-            >
-              <div>
-                <div className="text-slate-100 font-medium">{p.nombre}</div>
-                {p.descripcion && (
-                  <div className="text-slate-300/80 text-sm">{p.descripcion}</div>
-                )}
-              </div>
-              <div className="flex gap-2">
-                <button
-                  onClick={() => {
-                    setProyectoInvitando(p)
-                    setInviteOpen(true)
-                  }}
-                  className="p-2 rounded-lg hover:bg-slate-700"
-                >
-                  Invitar
-                </button>
-                <button
-                  onClick={() => {
-                    setEditing(p)
-                    setOpen(true)
-                  }}
-                  className="p-2 rounded-lg hover:bg-slate-700"
-                >
-                  <Pencil className="w-4 h-4 text-slate-300" />
-                </button>
-              </div>
-            </li>
-          ))}
-        </ul>
-
-        <ProyectoModal
-          open={open}
-          onClose={() => setOpen(false)}
-          initialData={editing}
-          empresaId={empresaId}
-          onSaved={load}
-        />
-        <InviteModal
-          open={inviteOpen}
-          onClose={() => setInviteOpen(false)}
-          title={proyectoInvitando ? `Invitar a ${proyectoInvitando.nombre}` : 'Invitar'}
-          onInvite={email => invitarUsuarioAProyecto(proyectoInvitando.id, email)}
-        />
       </div>
-
-      </>
-
-    )
-  }
+    </>
+  )
+}


### PR DESCRIPTION
## Summary
- overhaul navbar to use glass-like styling and include logo & logout
- remove logo from sidebar and pass logout handler to navbar
- restyle Empresas and Proyectos pages with glass cards and radial backgrounds for consistent design

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b01e8fb820832a8cf242753e93af12