### PR TITLE
feat: add user avatars and invitation flow

### DIFF
--- a/backend/controllers/invitacion.controller.js
+++ b/backend/controllers/invitacion.controller.js
@@ -1,0 +1,98 @@
+const { PrismaClient } = require('@prisma/client')
+const prisma = new PrismaClient()
+const crypto = require('crypto')
+const nodemailer = require('nodemailer')
+
+// Envia una invitación por correo electrónico
+exports.enviarInvitacion = async (req, res) => {
+  const { email, empresaId } = req.body
+
+  if (!email || !empresaId) {
+    return res.status(400).json({ mensaje: 'Email y empresaId son obligatorios' })
+  }
+
+  // Verifica que el usuario pertenece a la empresa
+  const pertenece = await prisma.empresa.findFirst({
+    where: {
+      id: Number(empresaId),
+      usuarios: { some: { id: req.usuario.id } }
+    },
+    select: { id: true }
+  })
+
+  if (!pertenece) {
+    return res.status(403).json({ mensaje: 'No tienes acceso a esta empresa' })
+  }
+
+  const token = crypto.randomBytes(20).toString('hex')
+
+  try {
+    await prisma.invitacion.create({
+      data: {
+        email,
+        token,
+        empresa: { connect: { id: Number(empresaId) } }
+      }
+    })
+
+    const link = `${process.env.FRONTEND_URL || 'http://localhost:5173'}/?invite=${token}`
+
+    if (process.env.SMTP_HOST) {
+      const transporter = nodemailer.createTransport({
+        host: process.env.SMTP_HOST,
+        port: Number(process.env.SMTP_PORT) || 587,
+        secure: false,
+        auth: {
+          user: process.env.SMTP_USER,
+          pass: process.env.SMTP_PASS
+        }
+      })
+
+      await transporter.sendMail({
+        to: email,
+        from: process.env.SMTP_FROM || process.env.SMTP_USER,
+        subject: 'Invitación a Taskery',
+        text: `Has sido invitado a Taskery. Regístrate aquí: ${link}`
+      })
+    } else {
+      console.log(`Invitación para ${email}: ${link}`)
+    }
+
+    res.json({ mensaje: 'Invitación enviada' })
+  } catch (error) {
+    console.error('Error enviando invitación', error)
+    res.status(500).json({ mensaje: 'Error enviando invitación' })
+  }
+}
+
+// Acepta una invitación y agrega el usuario a la empresa
+exports.aceptarInvitacion = async (req, res) => {
+  const { token } = req.body
+  if (!token) {
+    return res.status(400).json({ mensaje: 'Token requerido' })
+  }
+
+  try {
+    const invitacion = await prisma.invitacion.findUnique({ where: { token } })
+    if (!invitacion || invitacion.aceptada) {
+      return res.status(400).json({ mensaje: 'Invitación inválida' })
+    }
+
+    await prisma.usuario.update({
+      where: { id: req.usuario.id },
+      data: {
+        empresas: { connect: { id: invitacion.empresaId } }
+      }
+    })
+
+    await prisma.invitacion.update({
+      where: { id: invitacion.id },
+      data: { aceptada: true }
+    })
+
+    res.json({ mensaje: 'Invitación aceptada' })
+  } catch (error) {
+    console.error('Error aceptando invitación', error)
+    res.status(500).json({ mensaje: 'Error aceptando invitación' })
+  }
+}

--- a/backend/index.js
+++ b/backend/index.js
@@ -38,6 +38,7 @@ app.use('/api/usuarios', require('./routes/usuario.routes'))
 app.use('/api/proyectos', require('./routes/proyecto.routes'))
 app.use('/api/tareas', require('./routes/tarea.routes'))
 app.use('/api/timers', require('./routes/timer.routes'))
+app.use('/api/invitaciones', require('./routes/invitacion.routes'))
 
 // 👇 Añade esto para habilitar /api/me
 app.use('/api', require('./routes/auth.routes'))

--- a/backend/package.json
+++ b/backend/package.json
@@ -15,6 +15,7 @@
     "dotenv": "^17.2.1",
     "express": "^5.1.0",
     "express-session": "^1.18.2",
+    "nodemailer": "^6.9.8",
     "jsonwebtoken": "^9.0.2",
     "passport": "^0.7.0",
     "passport-github2": "^0.1.12",

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -34,6 +34,7 @@ model Empresa {
   color     String     @default("#FFFFFF")
   usuarios  Usuario[]  @relation("EmpresasUsuarios")
   proyectos Proyecto[]
+  invitaciones Invitacion[]
   createdAt DateTime   @default(now())
   updatedAt DateTime   @updatedAt
 }
@@ -119,4 +120,14 @@ model Timer {
   @@index([usuarioId])
   @@index([tareaId])
   @@index([inicio])
+}
+
+model Invitacion {
+  id        Int      @id @default(autoincrement())
+  email     String
+  token     String   @unique
+  empresaId Int
+  empresa   Empresa  @relation(fields: [empresaId], references: [id])
+  aceptada  Boolean  @default(false)
+  createdAt DateTime @default(now())
 }

--- a/backend/routes/invitacion.routes.js
+++ b/backend/routes/invitacion.routes.js
@@ -1,0 +1,10 @@
+const express = require('express')
+const { verificarToken } = require('../auth/jwt')
+const { enviarInvitacion, aceptarInvitacion } = require('../controllers/invitacion.controller')
+
+const router = express.Router()
+
+router.post('/', verificarToken, enviarInvitacion)
+router.post('/aceptar', verificarToken, aceptarInvitacion)
+
+module.exports = router

--- a/frontend/taskery/src/App.jsx
+++ b/frontend/taskery/src/App.jsx
@@ -7,7 +7,7 @@ import EmpresaCreateModal from "./components/EmpresaCreateModal";
 import ProyectoCreateModal from "./components/ProyectoCreateModal";
 import TareaCreateModal from "./components/TareaCreateModal";
 import { api } from "./lib/api";
-import { getToken, pickTokenFromURL, clearToken } from "./lib/auth";
+import { getToken, pickTokenFromURL, clearToken, getInviteToken, clearInviteToken } from "./lib/auth";
 
 // ✅ Importa el board con dnd-kit
 import KanbanBoardDnd from "./components/KanbanBoardDnd";
@@ -22,6 +22,7 @@ export default function App() {
   const [token, setToken] = useState(getToken());
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
+  const [usuario, setUsuario] = useState(null);
 
   // Empresas / Proyectos / Tareas
   const [empresas, setEmpresas] = useState([]);
@@ -44,27 +45,51 @@ export default function App() {
     setToken(getToken());
   }, []);
 
-  // 2) Carga empresas del usuario autenticado
-  useEffect(() => {
-    if (!token) return;
-
+  async function loadEmpresas() {
     setLoading(true);
     setError("");
 
+    try {
+      const res = await api.get("/empresas/mis-empresas");
+      const list = res.data || [];
+      setEmpresas(list);
+      if (list.length > 0 && !selectedEmpresa) {
+        setSelectedEmpresa(list[0]);
+      }
+    } catch (err) {
+      console.error("Error al cargar empresas:", err);
+      setError("No se pudieron cargar las empresas.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  // 2) Carga empresas del usuario autenticado
+  useEffect(() => {
+    if (!token) return;
+    loadEmpresas();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [token]);
+
+  // 2.1) Obtiene datos del usuario y acepta invitación si existe
+  useEffect(() => {
+    if (!token) return;
+
     api
-      .get("/empresas/mis-empresas")
-      .then((res) => {
-        const list = res.data || [];
-        setEmpresas(list);
-        if (list.length > 0 && !selectedEmpresa) {
-          setSelectedEmpresa(list[0]);
-        }
-      })
-      .catch((err) => {
-        console.error("Error al cargar empresas:", err);
-        setError("No se pudieron cargar las empresas.");
-      })
-      .finally(() => setLoading(false));
+      .get('/me')
+      .then((res) => setUsuario(res.data))
+      .catch(() => setUsuario(null));
+
+    const invite = getInviteToken();
+    if (invite) {
+      api
+        .post('/invitaciones/aceptar', { token: invite })
+        .then(() => {
+          clearInviteToken();
+          loadEmpresas();
+        })
+        .catch((err) => console.error('Error aceptando invitación:', err));
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [token]);
 
@@ -121,6 +146,18 @@ export default function App() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [token, selectedProyecto]);
 
+  function handleInvite() {
+    const email = prompt('Correo del usuario a invitar:');
+    if (!email || !selectedEmpresa) return;
+    api
+      .post('/invitaciones', { email, empresaId: selectedEmpresa.id })
+      .then(() => alert('Invitación enviada'))
+      .catch((err) => {
+        console.error('Error enviando invitación:', err);
+        alert('No se pudo enviar la invitación');
+      });
+  }
+
   // 5) Logout manual
   function handleLogout() {
     clearToken();
@@ -129,6 +166,7 @@ export default function App() {
     setProyectos([]);
     setSelectedEmpresa(null);
     setSelectedProyecto(null);
+    setUsuario(null);
     setTareas([]);
   }
 
@@ -192,6 +230,25 @@ export default function App() {
                   {error}
                 </span>
               )}
+              {usuario && (
+                <div className="flex items-center gap-2">
+                  {usuario.avatar && (
+                    <img
+                      src={usuario.avatar}
+                      alt="avatar"
+                      className="w-6 h-6 rounded-full"
+                    />
+                  )}
+                  <span className="text-sm">{usuario.nombre}</span>
+                </div>
+              )}
+              <button
+                onClick={handleInvite}
+                className="text-xs px-3 py-1.5 rounded-xl bg:white/5 hover:bg-white/10 border border-white/10"
+                disabled={!selectedEmpresa}
+              >
+                Invitar
+              </button>
               <button
                 onClick={handleLogout}
                 className="text-xs px-3 py-1.5 rounded-xl bg:white/5 hover:bg-white/10 border border-white/10"

--- a/frontend/taskery/src/lib/auth.js
+++ b/frontend/taskery/src/lib/auth.js
@@ -2,6 +2,7 @@
 // Encapsula todo lo de "token" para que App.jsx quede limpio
 
 const KEY = 'token'; // si prefieres sessionStorage, cambia aquí
+const INVITE_KEY = 'invite-token';
 
 export function setToken(token) {
   // Para MVP, localStorage. En producción: cookie httpOnly + refresh token.
@@ -16,13 +17,26 @@ export function clearToken() {
   localStorage.removeItem(KEY);
 }
 
+export function setInviteToken(token) {
+  localStorage.setItem(INVITE_KEY, token);
+}
+
+export function getInviteToken() {
+  return localStorage.getItem(INVITE_KEY) || '';
+}
+
+export function clearInviteToken() {
+  localStorage.removeItem(INVITE_KEY);
+}
+
 export function pickTokenFromURL() {
-  // Lee ?token=... y lo elimina de la barra de direcciones
+  // Lee ?token=... y ?invite=... y lo elimina de la barra de direcciones
   const params = new URLSearchParams(window.location.search);
   const urlToken = params.get('token');
-  if (urlToken) {
-    setToken(urlToken);
-    // Limpia el query para que al refrescar no repita el proceso
+  const inviteToken = params.get('invite');
+  if (urlToken) setToken(urlToken);
+  if (inviteToken) setInviteToken(inviteToken);
+  if (urlToken || inviteToken) {
     window.history.replaceState({}, document.title, window.location.pathname);
   }
 }


### PR DESCRIPTION
## Summary
- show logged user avatar and name next to logout
- allow inviting users via email and accepting invite
- add Prisma model and API routes for invitations

## Testing
- `npm test` *(backend, fails: Error: no test specified)*
- `npm test` *(frontend/taskery, fails: Missing script: "test")*
- `npm run lint` *(frontend/taskery, fails: 5 errors, 1 warning)*
- `npm run build` *(frontend/taskery)*

------
https://chatgpt.com/codex/tasks/task_e_68b0255be290832aab9e06de6f6c51e2