### PR TITLE
Handle auth check before user lookup

### DIFF
--- a/backend/routes/auth.routes.js
+++ b/backend/routes/auth.routes.js
@@ -44,6 +44,12 @@ router.get('/failed', (req, res) => {
 
 router.get('/me', verificarToken, async (req, res) => {
   try {
+    // Si por alguna razón el middleware no adjunta el usuario,
+    // respondemos con 401 en lugar de provocar un fallo interno.
+    if (!req.usuario || !req.usuario.id) {
+      return res.status(401).json({ mensaje: 'No autenticado' })
+    }
+
     const usuario = await prisma.usuario.findUnique({
       where: { id: req.usuario.id },
       include: { empresa: true }


### PR DESCRIPTION
## Summary
- prevent `/api/me` from throwing when `req.usuario` isn't set by returning `401`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b036574a10832aa6c6ccf4240bc0a5