### PR TITLE
Fix login redirect, timer sync and add edit modals

### DIFF
--- a/backend/routes/auth.routes.js
+++ b/backend/routes/auth.routes.js
@@ -17,7 +17,9 @@ router.get('/google/callback', passport.authenticate('google', {
   failureRedirect: '/auth/failed'
 }), (req, res) => {
   const token = generarToken(req.user)
-  res.redirect(`https://todo.bycram.dev/login/success?token=${token}`)
+  // Tras autenticarse, redirige a la raíz con el token en la query
+  // para que el frontend lo lea y limpie la URL posteriormente.
+  res.redirect(`https://todo.bycram.dev/?token=${token}`)
 })
 
 // ----------- GITHUB -----------
@@ -31,7 +33,8 @@ router.get('/github/callback', passport.authenticate('github', {
   failureRedirect: '/auth/failed'
 }), (req, res) => {
   const token = generarToken(req.user)
-  res.redirect(`https://todo.bycram.dev/login/success?token=${token}`)
+  // Igual que con Google, enviamos el token a la página principal.
+  res.redirect(`https://todo.bycram.dev/?token=${token}`)
 })
 
 // ----------- FALLO -----------

--- a/frontend/taskery/src/App.jsx
+++ b/frontend/taskery/src/App.jsx
@@ -397,7 +397,7 @@ export default function App() {
       </div>
 
       {/* Barra global del temporizador */}
-      <TimeBar />
+      <TimeBar onStop={loadTareas} />
     </ActiveTimerProvider>
   );
 }

--- a/frontend/taskery/src/components/EmpresaCreateModal.jsx
+++ b/frontend/taskery/src/components/EmpresaCreateModal.jsx
@@ -1,9 +1,9 @@
 // Modal de creación de empresa que usa BaseModal
-import React, { useState, useRef } from 'react'
+import React, { useState, useRef, useEffect } from 'react'
 import BaseModal from './BaseModal'
-import { crearEmpresa } from '@/services/empresas'
+import { crearEmpresa, editarEmpresa } from '@/services/empresas'
 
-export default function EmpresaCreateModal({ open, onClose, onCreated }) {
+export default function EmpresaCreateModal({ open, onClose, onCreated, initialData, onUpdated }) {
   const [nombre, setNombre] = useState('')
   const [descripcion, setDescripcion] = useState('')
   const [loading, setLoading] = useState(false)
@@ -11,6 +11,17 @@ export default function EmpresaCreateModal({ open, onClose, onCreated }) {
 
   const firstInputRef = useRef(null)
   const descId = 'empresa-modal-desc'
+  const isEdit = Boolean(initialData?.id)
+
+  useEffect(() => {
+    if (open && initialData) {
+      setNombre(initialData.nombre || '')
+      setDescripcion(initialData.descripcion || '')
+    } else if (open) {
+      setNombre('')
+      setDescripcion('')
+    }
+  }, [open, initialData])
 
   function resetAndClose() {
     setNombre('')
@@ -32,15 +43,23 @@ export default function EmpresaCreateModal({ open, onClose, onCreated }) {
 
     try {
       setLoading(true)
-      const nueva = await crearEmpresa({
-        nombre: nombre.trim(),
-        descripcion: descripcion.trim() || undefined,
-      })
-      onCreated?.(nueva)
+      if (isEdit) {
+        const actualizada = await editarEmpresa(initialData.id, {
+          nombre: nombre.trim(),
+          descripcion: descripcion.trim() || undefined,
+        })
+        onUpdated?.(actualizada)
+      } else {
+        const nueva = await crearEmpresa({
+          nombre: nombre.trim(),
+          descripcion: descripcion.trim() || undefined,
+        })
+        onCreated?.(nueva)
+      }
       resetAndClose()
     } catch (err) {
-      console.error('Error al crear empresa', err)
-      const msg = err?.response?.data?.mensaje || err?.message || 'No se pudo crear la empresa'
+      console.error(isEdit ? 'Error al editar empresa' : 'Error al crear empresa', err)
+      const msg = err?.response?.data?.mensaje || err?.message || 'No se pudo guardar la empresa'
       setError(msg)
     } finally {
       setLoading(false)
@@ -51,12 +70,12 @@ export default function EmpresaCreateModal({ open, onClose, onCreated }) {
     <BaseModal
       open={open}
       onClose={resetAndClose}
-      title="Nueva empresa"
+      title={isEdit ? 'Editar empresa' : 'Nueva empresa'}
       descriptionId={descId}
       initialFocusRef={firstInputRef}
     >
       <p id={descId} className="mt-1 text-sm text-white/70">
-        Crea una empresa para agrupar proyectos y usuarios.
+        {isEdit ? 'Edita los datos de la empresa.' : 'Crea una empresa para agrupar proyectos y usuarios.'}
       </p>
 
       {error && (
@@ -109,7 +128,7 @@ export default function EmpresaCreateModal({ open, onClose, onCreated }) {
             disabled={loading}
             className="rounded-xl bg-sky-500 px-4 py-2 font-semibold text-white hover:bg-sky-600 disabled:opacity-50"
           >
-            {loading ? 'Creando…' : 'Crear empresa'}
+            {loading ? (isEdit ? 'Guardando…' : 'Creando…') : isEdit ? 'Guardar cambios' : 'Crear empresa'}
           </button>
         </div>
       </form>

--- a/frontend/taskery/src/components/ProyectoCreateModal.jsx
+++ b/frontend/taskery/src/components/ProyectoCreateModal.jsx
@@ -1,9 +1,9 @@
 // src/components/ProyectoCreateModal.jsx
-import React, { useRef, useState } from 'react'
+import React, { useRef, useState, useEffect } from 'react'
 import BaseModal from './BaseModal'
-import { crearProyecto } from '@/services/proyectos'
+import { crearProyecto, editarProyecto } from '@/services/proyectos'
 
-export default function ProyectoCreateModal({ open, onClose, empresa, onCreated }) {
+export default function ProyectoCreateModal({ open, onClose, empresa, onCreated, initialData, onUpdated }) {
   const [nombre, setNombre] = useState('')
   const [horasMensuales, setHorasMensuales] = useState('')
   const [loading, setLoading] = useState(false)
@@ -11,6 +11,21 @@ export default function ProyectoCreateModal({ open, onClose, empresa, onCreated 
 
   const firstInputRef = useRef(null)
   const descId = 'proyecto-modal-desc'
+  const isEdit = Boolean(initialData?.id)
+
+  useEffect(() => {
+    if (open && initialData) {
+      setNombre(initialData.nombre || '')
+      setHorasMensuales(
+        initialData.horasMensuales !== undefined && initialData.horasMensuales !== null
+          ? String(initialData.horasMensuales)
+          : ''
+      )
+    } else if (open) {
+      setNombre('')
+      setHorasMensuales('')
+    }
+  }, [open, initialData])
 
   function resetAndClose() {
     setNombre('')
@@ -24,7 +39,7 @@ export default function ProyectoCreateModal({ open, onClose, empresa, onCreated 
     e.preventDefault()
     setError('')
 
-    if (!empresa?.id) {
+    if (!empresa?.id && !initialData?.empresaId) {
       setError('No hay empresa seleccionada')
       return
     }
@@ -42,16 +57,24 @@ export default function ProyectoCreateModal({ open, onClose, empresa, onCreated 
 
     try {
       setLoading(true)
-      const nuevo = await crearProyecto({
-        nombre: nombre.trim(),
-        empresaId: empresa.id,
-        horasMensuales: horas,
-      })
-      onCreated?.(nuevo)
+      if (isEdit) {
+        const actualizado = await editarProyecto(initialData.id, {
+          nombre: nombre.trim(),
+          horasMensuales: horas,
+        })
+        onUpdated?.(actualizado)
+      } else {
+        const nuevo = await crearProyecto({
+          nombre: nombre.trim(),
+          empresaId: empresa.id,
+          horasMensuales: horas,
+        })
+        onCreated?.(nuevo)
+      }
       resetAndClose()
     } catch (err) {
-      console.error('Error al crear proyecto', err)
-      const msg = err?.response?.data?.mensaje || err?.message || 'No se pudo crear el proyecto'
+      console.error(isEdit ? 'Error al editar proyecto' : 'Error al crear proyecto', err)
+      const msg = err?.response?.data?.mensaje || err?.message || 'No se pudo guardar el proyecto'
       setError(msg)
     } finally {
       setLoading(false)
@@ -62,12 +85,18 @@ export default function ProyectoCreateModal({ open, onClose, empresa, onCreated 
     <BaseModal
       open={open}
       onClose={resetAndClose}
-      title="Nuevo proyecto"
+      title={isEdit ? 'Editar proyecto' : 'Nuevo proyecto'}
       descriptionId={descId}
       initialFocusRef={firstInputRef}
     >
       <p id={descId} className="mt-1 text-sm text-white/70">
-        Crea un proyecto dentro de <span className="text-sky-200 font-medium">{empresa?.nombre || '—'}</span>.
+        {isEdit
+          ? 'Modifica los datos del proyecto.'
+          : 'Crea un proyecto dentro de '}
+        {!isEdit && (
+          <span className="text-sky-200 font-medium">{empresa?.nombre || '—'}</span>
+        )}
+        {!isEdit && '.'}
       </p>
 
       {error && (
@@ -121,7 +150,13 @@ export default function ProyectoCreateModal({ open, onClose, empresa, onCreated 
             disabled={loading}
             className="rounded-xl bg-sky-500 px-4 py-2 font-semibold text-white hover:bg-sky-600 disabled:opacity-50"
           >
-            {loading ? 'Creando…' : 'Crear proyecto'}
+            {loading
+              ? isEdit
+                ? 'Guardando…'
+                : 'Creando…'
+              : isEdit
+              ? 'Guardar cambios'
+              : 'Crear proyecto'}
           </button>
         </div>
       </form>

--- a/frontend/taskery/src/components/TimeBar.jsx
+++ b/frontend/taskery/src/components/TimeBar.jsx
@@ -9,9 +9,14 @@ function msToHMS(ms) {
   return `${h}:${m}:${ss}`;
 }
 
-export default function TimerBar() {
+export default function TimerBar({ onStop }) {
   const { active, runningForMs, stop } = useActiveTimer();
   if (!active) return null;
+
+  async function handleStop() {
+    await stop();
+    if (onStop) await onStop();
+  }
 
   return (
     <div className="fixed bottom-3 left-1/2 -translate-x-1/2 z-50
@@ -24,7 +29,7 @@ export default function TimerBar() {
       </strong>
       <span className="font-mono tabular-nums">{msToHMS(runningForMs)}</span>
       <button
-        onClick={stop}
+        onClick={handleStop}
         className="ml-2 px-3 py-1 rounded-md bg-red-600 hover:bg-red-700 text-sm"
         title="Parar temporizador"
       >

--- a/frontend/taskery/src/lib/auth.js
+++ b/frontend/taskery/src/lib/auth.js
@@ -37,6 +37,7 @@ export function pickTokenFromURL() {
   if (urlToken) setToken(urlToken);
   if (inviteToken) setInviteToken(inviteToken);
   if (urlToken || inviteToken) {
-    window.history.replaceState({}, document.title, window.location.pathname);
+    // Limpia los parámetros de la URL y vuelve a la raíz para evitar rutas como /login/success
+    window.history.replaceState({}, document.title, '/');
   }
 }

--- a/frontend/taskery/src/pages/EmpresasPage.jsx
+++ b/frontend/taskery/src/pages/EmpresasPage.jsx
@@ -11,6 +11,7 @@ import { clearToken } from '@/lib/auth';
 export default function EmpresasPage() {
   const [empresas, setEmpresas] = useState([]);
   const [open, setOpen] = useState(false);
+  const [editing, setEditing] = useState(null);
   const [usuario, setUsuario] = useState(null);
 
   async function load() {
@@ -46,7 +47,10 @@ export default function EmpresasPage() {
           <div className="flex justify-between mb-3">
             <h1 className="text-xl text-sky-200">Empresas</h1>
             <button
-              onClick={() => setOpen(true)}
+              onClick={() => {
+                setEditing(null);
+                setOpen(true);
+              }}
               className="px-3 py-2 rounded-lg bg-sky-600 hover:bg-sky-500"
             >
               Nueva
@@ -65,6 +69,15 @@ export default function EmpresasPage() {
                     <div className="text-slate-300/80 text-sm">{e.descripcion}</div>
                   )}
                 </div>
+                <button
+                  onClick={() => {
+                    setEditing(e);
+                    setOpen(true);
+                  }}
+                  className="text-xs px-3 py-1 rounded-lg bg-white/10 hover:bg-white/15 border border-white/10"
+                >
+                  Editar
+                </button>
               </li>
             ))}
           </ul>
@@ -72,8 +85,13 @@ export default function EmpresasPage() {
 
         <EmpresaCreateModal
           open={open}
-          onClose={() => setOpen(false)}
+          onClose={() => {
+            setOpen(false);
+            setEditing(null);
+          }}
           onCreated={load}
+          onUpdated={load}
+          initialData={editing}
         />
       </div>
       <TimeBar />

--- a/frontend/taskery/src/pages/ProyectosPage.jsx
+++ b/frontend/taskery/src/pages/ProyectosPage.jsx
@@ -11,6 +11,7 @@ import { clearToken } from '@/lib/auth';
 export default function ProyectosPage({ empresaId }) {
   const [proyectos, setProyectos] = useState([]);
   const [open, setOpen] = useState(false);
+  const [editing, setEditing] = useState(null);
   const [usuario, setUsuario] = useState(null);
 
   const load = useCallback(async () => {
@@ -53,7 +54,10 @@ export default function ProyectosPage({ empresaId }) {
           <div className="flex justify-between mb-3">
             <h1 className="text-xl text-sky-200">Proyectos</h1>
             <button
-              onClick={() => setOpen(true)}
+              onClick={() => {
+                setEditing(null);
+                setOpen(true);
+              }}
               className="px-3 py-2 rounded-lg bg-sky-600 hover:bg-sky-500"
             >
               Nuevo
@@ -72,6 +76,15 @@ export default function ProyectosPage({ empresaId }) {
                     <div className="text-slate-300/80 text-sm">{p.descripcion}</div>
                   )}
                 </div>
+                <button
+                  onClick={() => {
+                    setEditing(p);
+                    setOpen(true);
+                  }}
+                  className="text-xs px-3 py-1 rounded-lg bg-white/10 hover:bg-white/15 border border-white/10"
+                >
+                  Editar
+                </button>
               </li>
             ))}
           </ul>
@@ -79,9 +92,14 @@ export default function ProyectosPage({ empresaId }) {
 
         <ProyectoCreateModal
           open={open}
-          onClose={() => setOpen(false)}
+          onClose={() => {
+            setOpen(false);
+            setEditing(null);
+          }}
           empresa={empresaId ? { id: empresaId } : null}
           onCreated={load}
+          onUpdated={load}
+          initialData={editing}
         />
       </div>
       <TimeBar />


### PR DESCRIPTION
## Summary
- Redirect OAuth callbacks to site root with token so URL is cleaned
- Refresh dashboard timers when stopping via floating bar
- Allow editing empresas and proyectos via modal forms

## Testing
- `npm run lint`
- `npm test` (frontend)
- `npm test` (backend)


------
https://chatgpt.com/codex/tasks/task_e_68b0431ea0f4832a9b46d3c28e95ad8a