### PR TITLE
feat: search projects and delete entities

### DIFF
--- a/backend/controllers/empresa.controller.js
+++ b/backend/controllers/empresa.controller.js
@@ -141,8 +141,41 @@ async function listarEmpresasDelUsuario(req, res) {
   }
 }
 
+/**
+ * DELETE /empresas/:id
+ * Elimina una empresa si el usuario autenticado pertenece a ella.
+ */
+async function eliminarEmpresa(req, res) {
+  const { id } = req.params
+
+  try {
+    const empresaId = Number(id)
+    if (!empresaId) return res.status(400).json({ error: 'id inválido' })
+
+    // Verificar que el usuario pertenece a la empresa
+    const pertenece = await prisma.empresa.findFirst({
+      where: {
+        id: empresaId,
+        usuarios: { some: { id: req.usuario.id } },
+      },
+      select: { id: true },
+    })
+
+    if (!pertenece) {
+      return res.status(403).json({ error: 'No tienes acceso a esta empresa' })
+    }
+
+    await prisma.empresa.delete({ where: { id: empresaId } })
+    return res.json({ ok: true })
+  } catch (error) {
+    console.error('[eliminarEmpresa] Error:', error)
+    return res.status(500).json({ error: 'Error al eliminar empresa' })
+  }
+}
+
 // Exporta cada función como propiedad del objeto exports
 exports.crearEmpresa = crearEmpresa
 exports.editarEmpresa = editarEmpresa
 exports.obtenerEmpresaPorId = obtenerEmpresaPorId
 exports.listarEmpresasDelUsuario = listarEmpresasDelUsuario
+exports.eliminarEmpresa = eliminarEmpresa

--- a/backend/controllers/proyecto.controller.js
+++ b/backend/controllers/proyecto.controller.js
@@ -174,5 +174,43 @@ async function editarProyecto(req, res) {
   }
 }
 
+/**
+ * DELETE /proyectos/:id
+ * Elimina un proyecto si el usuario pertenece a la empresa del proyecto.
+ */
+async function eliminarProyecto(req, res) {
+  const { id } = req.params
+  const usuarioId = req.usuario?.id
 
-module.exports = { crearProyecto, listarProyectosPorEmpresa, editarProyecto }
+  try {
+    const proyectoId = Number(id)
+    if (!proyectoId) return res.status(400).json({ error: 'id inválido' })
+
+    const proyecto = await prisma.proyecto.findUnique({
+      where: { id: proyectoId },
+      select: { id: true, empresaId: true },
+    })
+    if (!proyecto) return res.status(404).json({ error: 'Proyecto no encontrado' })
+
+    // Autorizar
+    const pertenece = await prisma.empresa.findFirst({
+      where: {
+        id: proyecto.empresaId,
+        usuarios: { some: { id: Number(usuarioId) } },
+      },
+      select: { id: true },
+    })
+    if (!pertenece) {
+      return res.status(403).json({ error: 'No tienes acceso a este proyecto' })
+    }
+
+    await prisma.proyecto.delete({ where: { id: proyectoId } })
+    return res.json({ ok: true })
+  } catch (error) {
+    console.error('[eliminarProyecto] Error:', error)
+    return res.status(500).json({ error: 'Error al eliminar proyecto' })
+  }
+}
+
+
+module.exports = { crearProyecto, listarProyectosPorEmpresa, editarProyecto, eliminarProyecto }

--- a/backend/controllers/tarea.controller.js
+++ b/backend/controllers/tarea.controller.js
@@ -249,6 +249,38 @@ async function editarTarea(req, res) {
   }
 }
 
+// Eliminar tarea
+async function eliminarTarea(req, res) {
+  try {
+    const { id } = req.params
+    const tareaId = Number(id)
+    if (!tareaId) return res.status(400).json({ error: 'id inválido' })
+
+    const tarea = await prisma.tarea.findUnique({
+      where: { id: tareaId },
+      select: { id: true, proyecto: { select: { empresaId: true } } },
+    })
+    if (!tarea) return res.status(404).json({ error: 'Tarea no encontrada' })
+
+    const pertenece = await prisma.empresa.findFirst({
+      where: {
+        id: tarea.proyecto.empresaId,
+        usuarios: { some: { id: req.usuario.id } },
+      },
+      select: { id: true },
+    })
+    if (!pertenece) {
+      return res.status(403).json({ error: 'No tienes acceso a esta tarea' })
+    }
+
+    await prisma.tarea.delete({ where: { id: tareaId } })
+    return res.json({ ok: true })
+  } catch (error) {
+    console.error('[eliminarTarea] Error:', error)
+    return res.status(500).json({ error: 'Error al eliminar tarea' })
+  }
+}
+
 
 
 // PATCH /tareas/ordenar
@@ -300,4 +332,5 @@ module.exports = {
   listarTareasPorProyecto,
   editarTarea,
   reordenarTareas,
+  eliminarTarea,
 }

--- a/backend/routes/empresa.routes.js
+++ b/backend/routes/empresa.routes.js
@@ -17,6 +17,9 @@ router.put('/:id', verificarToken, empresaController.editarEmpresa);
 // GET /empresas/:id  -> Devuelve la empresa, sus proyectos y usuarios
 router.get('/:id', verificarToken, empresaController.obtenerEmpresaPorId);
 
+// Eliminar empresa
+router.delete('/:id', verificarToken, empresaController.eliminarEmpresa);
+
 // Exportamos este router para poder usarlo en index.js
 module.exports = router;
 

--- a/backend/routes/proyecto.routes.js
+++ b/backend/routes/proyecto.routes.js
@@ -1,7 +1,7 @@
 const express = require('express')
 const router = express.Router()
 
-const { crearProyecto, listarProyectosPorEmpresa, editarProyecto } = require('../controllers/proyecto.controller')
+const { crearProyecto, listarProyectosPorEmpresa, editarProyecto, eliminarProyecto } = require('../controllers/proyecto.controller')
 const { verificarToken } = require('../auth/jwt')
 
 // Crear nuevo proyecto (requiere token)
@@ -12,5 +12,8 @@ router.get('/', verificarToken, listarProyectosPorEmpresa)
 
 // Editar proyecto
 router.put('/:id', verificarToken, editarProyecto)
+
+// Eliminar proyecto
+router.delete('/:id', verificarToken, eliminarProyecto)
 
 module.exports = router

--- a/backend/routes/tarea.routes.js
+++ b/backend/routes/tarea.routes.js
@@ -16,6 +16,9 @@ router.post('/', tareaController.crearTarea);
 // Ahora acepta nombre, descripcion, estado y prioridad
 router.put('/:id', tareaController.editarTarea);
 
+// Eliminar tarea
+router.delete('/:id', tareaController.eliminarTarea);
+
 // GET /tareas/:proyectoId -> Lista tareas del proyecto
 // Usamos la función desde el controlador
 router.get('/:proyectoId', tareaController.listarTareasPorProyecto)

--- a/frontend/taskery/src/App.jsx
+++ b/frontend/taskery/src/App.jsx
@@ -11,7 +11,7 @@ import { getToken, pickTokenFromURL, clearToken, getInviteToken, clearInviteToke
 
 // ✅ Importa el board con dnd-kit
 import KanbanBoardDnd from "./components/KanbanBoardDnd";
-import { actualizarEstadoTarea, reordenarTareas } from "./services/tareas";
+import { actualizarEstadoTarea, reordenarTareas, eliminarTarea } from "./services/tareas";
 import { getTimersByTask } from "./services/timers";
 
 // ✅ NUEVO: Contexto del timer + barra
@@ -358,6 +358,11 @@ export default function App() {
                     // Asegura consistencia final desde el backend
                     await loadTareas();
                   }
+                }}
+                onDelete={async (task) => {
+                  if (!window.confirm("¿Eliminar tarea?")) return;
+                  await eliminarTarea(task.id);
+                  await loadTareas();
                 }}
               />
             )}

--- a/frontend/taskery/src/components/KanbanBoardDnd.jsx
+++ b/frontend/taskery/src/components/KanbanBoardDnd.jsx
@@ -18,7 +18,7 @@ import {
   arrayMove,
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { Pencil, Play, Square } from "lucide-react";
+import { Pencil, Play, Square, Trash } from "lucide-react";
 import TareaCreateModal from "@/components/TareaCreateModal";
 
 // 👇 IMPORTA EL CONTEXTO DEL TIMER
@@ -58,7 +58,7 @@ function msToHMS(ms) {
   return `${h}:${m}:${ss}`;
 }
 
-function TareaCardSortable({ tarea, onEdit, activeTareaId, startTimer, stopTimer }) {
+function TareaCardSortable({ tarea, onEdit, activeTareaId, startTimer, stopTimer, onDelete }) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
     useSortable({ id: String(tarea.id) });
 
@@ -179,6 +179,17 @@ function TareaCardSortable({ tarea, onEdit, activeTareaId, startTimer, stopTimer
             >
               <Pencil className="w-4 h-4 text-slate-300" />
             </button>
+            <button
+              onMouseDown={stopDnd}
+              onClick={(e) => {
+                stopDnd(e);
+                onDelete?.(tarea);
+              }}
+              className="p-1 rounded hover:bg-slate-700 text-red-400"
+              title="Eliminar tarea"
+            >
+              <Trash className="w-4 h-4" />
+            </button>
           </div>
         </div>
       )}
@@ -238,6 +249,7 @@ export default function KanbanBoardDnd({
   onReorderSameColumn, // (col, idsOrdenados)
   onMoveToColumn, // (tareaId, toCol, idsTarget, idsSource)
   onAfterSave, // opcional: refrescar tras guardar en el modal
+  onDelete,
 }) {
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
@@ -423,10 +435,13 @@ export default function KanbanBoardDnd({
                               onAfterSave?.();
                             }}
                             onEdit={(task) => {
-                              setEditing(task);
-                              setEditOpen(true);
-                            }}
-                          />
+                          setEditing(task);
+                          setEditOpen(true);
+                        }}
+                        onDelete={(task) => {
+                          onDelete?.(task);
+                        }}
+                      />
                         </React.Fragment>
                       ))}
 

--- a/frontend/taskery/src/pages/EmpresasPage.jsx
+++ b/frontend/taskery/src/pages/EmpresasPage.jsx
@@ -1,6 +1,6 @@
 // src/pages/EmpresasPage.jsx
 import React, { useEffect, useState } from 'react';
-import { listarMisEmpresas } from '@/services/empresas';
+import { listarMisEmpresas, eliminarEmpresa } from '@/services/empresas';
 import EmpresaCreateModal from '@/components/EmpresaCreateModal';
 import Navbar from '@/components/Navbar';
 import { ActiveTimerProvider } from '@/context/ActiveTimerContext';
@@ -69,15 +69,27 @@ export default function EmpresasPage() {
                     <div className="text-slate-300/80 text-sm">{e.descripcion}</div>
                   )}
                 </div>
-                <button
-                  onClick={() => {
-                    setEditing(e);
-                    setOpen(true);
-                  }}
-                  className="text-xs px-3 py-1 rounded-lg bg-white/10 hover:bg-white/15 border border-white/10"
-                >
-                  Editar
-                </button>
+                <div className="flex gap-2">
+                  <button
+                    onClick={() => {
+                      setEditing(e);
+                      setOpen(true);
+                    }}
+                    className="text-xs px-3 py-1 rounded-lg bg-white/10 hover:bg-white/15 border border-white/10"
+                  >
+                    Editar
+                  </button>
+                  <button
+                    onClick={async () => {
+                      if (!window.confirm('¿Eliminar empresa?')) return;
+                      await eliminarEmpresa(e.id);
+                      load();
+                    }}
+                    className="text-xs px-3 py-1 rounded-lg bg-red-600 hover:bg-red-500 border border-white/10"
+                  >
+                    Eliminar
+                  </button>
+                </div>
               </li>
             ))}
           </ul>

--- a/frontend/taskery/src/pages/ProyectosPage.jsx
+++ b/frontend/taskery/src/pages/ProyectosPage.jsx
@@ -1,6 +1,6 @@
 // src/pages/ProyectosPage.jsx
 import React, { useEffect, useState, useCallback } from 'react';
-import { listarProyectosPorEmpresa } from '@/services/proyectos';
+import { listarProyectosPorEmpresa, eliminarProyecto } from '@/services/proyectos';
 import { listarMisEmpresas } from '@/services/empresas';
 import ProyectoCreateModal from '@/components/ProyectoCreateModal';
 import Navbar from '@/components/Navbar';
@@ -13,6 +13,7 @@ export default function ProyectosPage({ empresaId: initialEmpresaId }) {
   const [empresas, setEmpresas] = useState([]);
   const [empresaId, setEmpresaId] = useState(initialEmpresaId || '');
   const [proyectos, setProyectos] = useState([]);
+  const [query, setQuery] = useState('');
   const [open, setOpen] = useState(false);
   const [editing, setEditing] = useState(null);
   const [usuario, setUsuario] = useState(null);
@@ -111,8 +112,19 @@ export default function ProyectosPage({ empresaId: initialEmpresaId }) {
             </button>
           </div>
 
+          <div className="mb-3">
+            <input
+              type="text"
+              placeholder="Buscar proyectos..."
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              className="w-full mb-2 px-2 py-1 rounded-lg bg-slate-800 text-white"
+            />
+          </div>
           <ul className="space-y-2">
-            {proyectos.map((p) => (
+            {proyectos
+              .filter((p) => p.nombre.toLowerCase().includes(query.toLowerCase()))
+              .map((p) => (
               <li
                 key={p.id}
                 className="p-3 rounded-xl bg-slate-800 border border-white/10 flex justify-between items-center"
@@ -123,17 +135,29 @@ export default function ProyectosPage({ empresaId: initialEmpresaId }) {
                     <div className="text-slate-300/80 text-sm">{p.descripcion}</div>
                   )}
                 </div>
-                <button
-                  onClick={() => {
-                    setEditing(p);
-                    setOpen(true);
-                  }}
-                  className="text-xs px-3 py-1 rounded-lg bg-white/10 hover:bg-white/15 border border-white/10"
-                >
-                  Editar
-                </button>
+                <div className="flex gap-2">
+                  <button
+                    onClick={() => {
+                      setEditing(p);
+                      setOpen(true);
+                    }}
+                    className="text-xs px-3 py-1 rounded-lg bg-white/10 hover:bg-white/15 border border-white/10"
+                  >
+                    Editar
+                  </button>
+                  <button
+                    onClick={async () => {
+                      if (!window.confirm('¿Eliminar proyecto?')) return;
+                      await eliminarProyecto(p.id);
+                      load();
+                    }}
+                    className="text-xs px-3 py-1 rounded-lg bg-red-600 hover:bg-red-500 border border-white/10"
+                  >
+                    Eliminar
+                  </button>
+                </div>
               </li>
-            ))}
+              ))}
           </ul>
         </main>
 

--- a/frontend/taskery/src/services/empresas.js
+++ b/frontend/taskery/src/services/empresas.js
@@ -20,3 +20,8 @@ export async function editarEmpresa(id, payload) {
   const { data } = await api.put(`/empresas/${id}`, payload);
   return data;
 }
+
+export async function eliminarEmpresa(id) {
+  const { data } = await api.delete(`/empresas/${id}`);
+  return data;
+}

--- a/frontend/taskery/src/services/proyectos.js
+++ b/frontend/taskery/src/services/proyectos.js
@@ -15,3 +15,8 @@ export async function editarProyecto(id, payload) {
   const { data } = await api.put(`/proyectos/${id}`, payload);
   return data;
 }
+
+export async function eliminarProyecto(id) {
+  const { data } = await api.delete(`/proyectos/${id}`);
+  return data;
+}

--- a/frontend/taskery/src/services/tareas.js
+++ b/frontend/taskery/src/services/tareas.js
@@ -80,6 +80,11 @@ export async function reordenarTareas(proyectoId, estado, idsOrdenados) {
   return data
 }
 
+export async function eliminarTarea(id) {
+  const { data } = await api.delete(`/tareas/${id}`)
+  return data
+}
+
 /**
  * (Opcional) Mover una tarea entre columnas y reordenar ambas listas.
  * Útil si quieres orquestarlo desde aquí en lugar de App.jsx


### PR DESCRIPTION
## Summary
- add API endpoints and UI to delete empresas, proyectos, tareas
- add search bar to filter projects

## Testing
- `cd backend && npm test`
- `cd frontend/taskery && npm test`
- `cd frontend/taskery && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b061f7bf84832ab253be0eb31a40a2